### PR TITLE
not using chrome's widevinecdm plugin, importing it manually..

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,7 @@
 const electron = require("electron");
 const app = electron.app;
+const widevine = require('electron-widevinecdm').load(app);
 let window;
-
-// Add Chromium's Widevine plugin back into Electron
-const widevinePath = require("child_process").execSync("find '/Applications/Google Chrome.app' -name widevinecdmadapter.plugin").toString().split("\n")[0];
-app.commandLine.appendSwitch("widevine-cdm-path", widevinePath)
-app.commandLine.appendSwitch("widevine-cdm-version", "0")
 
 // Lauch the app
 app.on("ready", function(){

--- a/package.json
+++ b/package.json
@@ -1,3 +1,6 @@
 {
-  "name": "Stopify"
+  "name": "Stopify",
+  "dependencies": {
+    "electron-widevinecdm": "^5.0.2"
+  }
 }


### PR DESCRIPTION
When I opened stopify today, I was shown this message (In fact I've been seeing this message this entire week but usually closing and opening the Stopify.app again worked):
![Main Page Error](https://lh5.googleusercontent.com/arjBFd9vC09olnit6Wt7tuxpvVV3cMxeFCNOaSXs7vNpcuwC7drry_uW65BtzDtiI8oMbBhHpRl-9NX_bkJL=w2560-h1272-rw)

And after opening the devTools, I saw this:

![devToolsError](https://lh5.googleusercontent.com/Z_R4bOYPuhpK5YQWehB7ksnrJ9XUR-rxGztEZoefPcjp0KPOMLwGTmjkeBvpbAMpc2j6KdrosygAEQtO97M1=w2560-h1272-rw)

- Electron is using a previous Chrome version and according to the [docs](https://electronjs.org/docs/tutorial/using-widevine-cdm-plugin) about the widevine plugin:

> The major version of Chrome browser has to be the same with the Chrome version used by Electron, otherwise the plugin will not work even though navigator.plugins would show it has been loaded.

The chrome version on electron is behind the Google Chrome.app's version. So, we could use this npm package.. That way, we could be independent of the browser. I added [this](https://github.com/candh/stopify/blob/master/index.js#L3) line of code, ran it and it works perfectly... Consider merging and packaging, I'm already using it! 

Great job on the original project 👍 